### PR TITLE
Update Craftcloud Client base URL to craftcloud3d.com

### DIFF
--- a/lib/all3dp/api.rb
+++ b/lib/all3dp/api.rb
@@ -4,8 +4,11 @@ module All3DP
   # Handle all calls to the API.
   class API
     class Error < StandardError; end
+
     class BadGatewayError < Error; end
+
     class GatewayTimeoutError < Error; end
+
     class ServiceUnavailableError < Error; end
 
     def create_configuration(items:)

--- a/lib/all3dp/configuration.rb
+++ b/lib/all3dp/configuration.rb
@@ -10,7 +10,7 @@ module All3DP
     end
 
     def url
-      "https://app.craftcloud3d.com/configuration/#{id}"
+      "https://craftcloud3d.com/configuration/#{id}"
     end
 
     def self.create(model_urls:)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe All3DP::Configuration do
 
       expect(subject.id).to eq("some-configuration-id")
       expect(subject.url).to eq(
-        "https://app.craftcloud3d.com/configuration/some-configuration-id",
+        "https://craftcloud3d.com/configuration/some-configuration-id",
       )
     end
   end


### PR DESCRIPTION
We migrated from app.craftcloud3d.com to craftcloud3d.com.

The old URL still works via 301 redirect but this would be cleaner